### PR TITLE
Fix gamepad button release events not firing

### DIFF
--- a/packages/engine/src/input/GamepadController.ts
+++ b/packages/engine/src/input/GamepadController.ts
@@ -66,20 +66,20 @@ export class GamepadController {
 
       this.state.buttons.set(index, isPressed);
 
+      const action = this.buttonBindings.get(index);
+
       // Emit events on state change
-      if (isPressed && !wasPressed) {
-        const action = this.buttonBindings.get(index);
-        if (action) {
-          const inputState: InputState = {
-            action,
-            pressed: true,
-            held: false,
-            released: false,
-            timestamp: performance.now(),
-            duration: 0,
-          };
-          this.notifyListeners(inputState);
-        }
+      if (action && isPressed !== wasPressed) {
+        const inputState: InputState = {
+          action,
+          pressed: isPressed && !wasPressed,
+          held: false,
+          released: !isPressed && wasPressed,
+          timestamp: performance.now(),
+          duration: 0,
+        };
+
+        this.notifyListeners(inputState);
       }
     });
 


### PR DESCRIPTION
## Summary
- emit button release events when polling gamepads so inputs clear correctly
- keep input listeners informed of button state changes for gamepads

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d88a24e708327acafcf79909c141a)